### PR TITLE
Flush stdout after printing color

### DIFF
--- a/main.c
+++ b/main.c
@@ -90,6 +90,7 @@ int main(int argc, char *argv[]) {
 			break;
 		}
 		XDestroyImage(image);
+		fflush(stdout);
 	}
 
 	/* will be done on connection close anw */


### PR DESCRIPTION
Had some issues piping to scripts. Flushing `stdout` after printing fixes it.

It looks the most recent commit upstream does the same: https://github.com/Ancurio/colorpicker/commit/287676947e6e3b5b0cee784aeb1638cf22f0ce17